### PR TITLE
Change editorconfig according to the real state of styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
-insert_final_newline = false
+insert_final_newline = true


### PR DESCRIPTION
It looks like no one has ever enabled editor config in their IDE so defaulty end of line was lf while in editorconfig there is set up to:

```
end_of_line = crlf
```

![image](https://user-images.githubusercontent.com/14861637/85200409-620e6c00-b2f7-11ea-9f8d-3e614712afa3.png)

Because of that whenever I (with enabled reading editorconfig) change the code somewhere it changes endlines everywhere.

As we don't want for sure to change the entire codebase to use crlf I've updated configuration file to mach existing settings.
